### PR TITLE
Update refproxy for new interface with Spike.

### DIFF
--- a/config/config.h
+++ b/config/config.h
@@ -31,7 +31,11 @@ extern unsigned long EMU_RAM_SIZE;
 
 // first valid instruction's address, difftest starts from this instruction
 #ifndef FIRST_INST_ADDRESS
-#define FIRST_INST_ADDRESS 0x10000000
+#if DIFF_PROXY == NemuProxy
+#define FIRST_INST_ADDRESS 0x10000000UL
+#else
+#define FIRST_INST_ADDRESS 0x80000000UL
+#endif
 #endif
 
 // sdcard image to be used in simulation
@@ -54,7 +58,7 @@ extern unsigned long EMU_FLASH_SIZE;
 // Difftest interface config
 // -----------------------------------------------------------------------
 #ifndef DIFF_PROXY
-#define DIFF_PROXY NemuProxy
+#define DIFF_PROXY SpikeProxy
 #endif
 
 // max physical register file size

--- a/src/test/csrc/difftest/difftest.cpp
+++ b/src/test/csrc/difftest/difftest.cpp
@@ -20,6 +20,7 @@
 #include "flash.h"
 #include "spikedasm.h"
 #include "sparseram.h"
+#include "refproxy.h"
 
 static const char *reg_name[DIFFTEST_NR_REG+1] = {
   "$0",  "ra",  "sp",   "gp",   "tp",  "t0",  "t1",   "t2",
@@ -52,6 +53,10 @@ int difftest_init() {
 }
 
 int init_nemuproxy() {
+#if DIFF_PROXY == SpikeProxy
+  // For Spike, only create one .so lib even for multicore
+  SpikeProxy::spike_init();
+#endif
   for (int i = 0; i < NUM_CORES; i++) {
     difftest[i]->update_nemuproxy(i);
   }

--- a/src/test/csrc/difftest/refproxy.cpp
+++ b/src/test/csrc/difftest/refproxy.cpp
@@ -17,9 +17,26 @@
 #include "refproxy.h"
 #include <unistd.h>
 #include <dlfcn.h>
+#include <cstddef>
 
+// Initialize global and static variables
 uint8_t* goldenMem = NULL;
 const char *difftest_ref_so = NULL;
+
+void* SpikeProxy::handle = nullptr;
+void (*SpikeProxy::sim_memcpy)(size_t coreid, paddr_t nemu_addr, void *dut_buf, size_t n, bool direction) = nullptr;
+void (*SpikeProxy::sim_regcpy)(size_t coreid, void *dut, bool direction) = nullptr;
+void (*SpikeProxy::sim_csrcpy)(size_t coreid, void *dut, bool direction) = nullptr;
+void (*SpikeProxy::sim_uarchstatus_cpy)(size_t coreid, void *dut, bool direction) = nullptr;
+int (*SpikeProxy::sim_store_commit)(size_t coreid, uint64_t *saddr, uint64_t *sdata, uint8_t *smask) = nullptr;
+void (*SpikeProxy::sim_exec)(size_t coreid, uint64_t n) = nullptr;
+vaddr_t (*SpikeProxy::sim_guided_exec)(size_t coreid, void *disambiguate_para) = nullptr;
+void (*SpikeProxy::sim_update_config)(size_t coreid, void *config) = nullptr;
+void (*SpikeProxy::sim_raise_intr)(size_t coreid, uint64_t no) = nullptr;
+void (*SpikeProxy::sim_isa_reg_display)(size_t coreid) = nullptr;
+void (*SpikeProxy::sim_query)(size_t coreid, void *result_buffer, uint64_t type) = nullptr;
+void (*SpikeProxy::sim_debug_mem_sync)(paddr_t addr, void *bytes, size_t size) = nullptr;
+void (*SpikeProxy::sim_load_flash_bin)(void *flash_bin, size_t size) = nullptr;
 
 #define check_and_assert(func)                                \
   do {                                                        \
@@ -114,10 +131,12 @@ void ref_misc_put_gmaddr(uint8_t* ptr) {
   goldenMem = ptr;
 }
 
-SpikeProxy::SpikeProxy(int coreid) {
+void SpikeProxy::spike_init() 
+{
   if (difftest_ref_so == NULL) {
     printf("--diff is not given, "
-        "try to use $(" SPIKE_ENV_VARIABLE ")/" SPIKE_SO_FILENAME " by default\n");
+           "try to use $(" SPIKE_ENV_VARIABLE ")/" SPIKE_SO_FILENAME
+           " by default\n");
     const char *spike_home = getenv(SPIKE_ENV_VARIABLE);
     if (spike_home == NULL) {
       printf("FATAL: $(" SPIKE_ENV_VARIABLE ") is not defined!\n");
@@ -132,58 +151,56 @@ SpikeProxy::SpikeProxy(int coreid) {
 
   printf("SpikeProxy using %s\n", difftest_ref_so);
 
-  void *handle = dlmopen(LM_ID_NEWLM, difftest_ref_so, RTLD_LAZY | RTLD_DEEPBIND);
+  handle = dlmopen(LM_ID_NEWLM, difftest_ref_so, RTLD_LAZY | RTLD_DEEPBIND);
   if (!handle) {
     printf("%s\n", dlerror());
     assert(0);
   }
 
-  auto spike_init = (void (*)(int))dlsym(handle, "difftest_init");
-  check_and_assert(spike_init);
+  auto sim_init = (void (*)())dlsym(handle, "difftest_init");
+  check_and_assert(sim_init);
 
-  this->memcpy = (void (*)(paddr_t, void *, size_t, bool))dlsym(handle, "difftest_memcpy");
-  check_and_assert(this->memcpy);
+  sim_memcpy = (void (*)(size_t, paddr_t, void *, size_t, bool))dlsym(handle, "difftest_memcpy");
+  check_and_assert(sim_memcpy);
 
-  regcpy = (void (*)(void *, bool))dlsym(handle, "difftest_regcpy");
-  check_and_assert(regcpy);
+  sim_regcpy = (void (*)(size_t, void *, bool))dlsym(handle, "difftest_regcpy");
+  check_and_assert(sim_regcpy);
 
-  csrcpy = (void (*)(void *, bool))dlsym(handle, "difftest_csrcpy");
-  check_and_assert(csrcpy);
+  sim_csrcpy = (void (*)(size_t, void *, bool))dlsym(handle, "difftest_csrcpy");
+  check_and_assert(sim_csrcpy);
 
-  uarchstatus_cpy = (void (*)(void *, bool))dlsym(handle, "difftest_uarchstatus_cpy");
-  check_and_assert(uarchstatus_cpy);
+  sim_uarchstatus_cpy = (void (*)(size_t, void *, bool))dlsym(handle, "difftest_uarchstatus_cpy");
+  check_and_assert(sim_uarchstatus_cpy);
 
-  exec = (void (*)(uint64_t))dlsym(handle, "difftest_exec");
-  check_and_assert(exec);
+  sim_exec = (void (*)(size_t, uint64_t))dlsym(handle, "difftest_exec");
+  check_and_assert(sim_exec);
 
-  guided_exec = (vaddr_t (*)(void *))dlsym(handle, "difftest_guided_exec");
-  check_and_assert(guided_exec);
+  sim_guided_exec = (vaddr_t (*)(size_t, void *))dlsym(handle, "difftest_guided_exec");
+  check_and_assert(sim_guided_exec);
 
-  update_config = (void (*)(void *))dlsym(handle, "update_dynamic_config");
-  check_and_assert(update_config);
+  sim_update_config = (void (*)(size_t, void *))dlsym(handle, "update_dynamic_config");
+  check_and_assert(sim_update_config);
 
-  store_commit = (int (*)(uint64_t*, uint64_t*, uint8_t*))dlsym(handle, "difftest_store_commit");
-  check_and_assert(store_commit);
+  sim_store_commit = (int (*)(size_t, uint64_t*, uint64_t*, uint8_t*))dlsym(handle, "difftest_store_commit");
+  check_and_assert(sim_store_commit);
 
-  raise_intr = (void (*)(uint64_t))dlsym(handle, "difftest_raise_intr");
-  check_and_assert(raise_intr);
+  sim_raise_intr = (void (*)(size_t, uint64_t))dlsym(handle, "difftest_raise_intr");
+  check_and_assert(sim_raise_intr);
 
-  isa_reg_display = (void (*)(void))dlsym(handle, "isa_reg_display");
-  check_and_assert(isa_reg_display);
+  sim_isa_reg_display = (void (*)(size_t))dlsym(handle, "isa_reg_display");
+  check_and_assert(sim_isa_reg_display);
 
-  debug_mem_sync = (void (*)(paddr_t, void *, size_t))dlsym(handle, "debug_mem_sync");
-  // check_and_assert(debug_mem_sync);
+  // core independent
+  sim_debug_mem_sync = (void (*)(paddr_t, void *, size_t))dlsym(handle, "debug_mem_sync");
+  check_and_assert(sim_debug_mem_sync);
 
-  query = (void (*)(void*, uint64_t))dlsym(handle, "difftest_query_ref");
+  sim_query = (void (*)(size_t, void*, uint64_t))dlsym(handle, "difftest_query_ref");
 #ifdef ENABLE_RUNHEAD
-  check_and_assert(query);
+  check_and_assert(sim_query);
 #endif
 
-  auto spike_difftest_set_mhartid = (void (*)(int))dlsym(handle, "difftest_set_mhartid");
-  if (NUM_CORES > 1) {
-    check_and_assert(spike_difftest_set_mhartid);
-    spike_difftest_set_mhartid(coreid);
-  }
+  // core independent
+  sim_load_flash_bin = (void (*)(void*, size_t))dlsym(handle, "difftest_load_flash");;
 
   auto spike_misc_put_gmaddr = (void (*)(void*))dlsym(handle, "difftest_put_gmaddr");
   if (NUM_CORES > 1) {
@@ -191,6 +208,61 @@ SpikeProxy::SpikeProxy(int coreid) {
     assert(goldenMem);
     spike_misc_put_gmaddr(goldenMem);
   }
+  
+  sim_init();
+}
 
-  spike_init(0);
+void SpikeProxy::memcpy(paddr_t nemu_addr, void *dut_buf, size_t n, bool direction)
+{
+  sim_memcpy(coreid, nemu_addr, dut_buf, n, direction);
+}
+
+void SpikeProxy::regcpy(void *dut, bool direction)
+{
+  sim_regcpy(coreid, dut, direction);
+}
+
+void SpikeProxy::csrcpy(void *dut, bool direction)
+{
+  sim_csrcpy(coreid, dut, direction);
+}
+
+void SpikeProxy::uarchstatus_cpy(void *dut, bool direction)
+{
+  sim_uarchstatus_cpy(coreid, dut, direction);
+}
+
+int SpikeProxy::store_commit(uint64_t *saddr, uint64_t *sdata, uint8_t *smask)
+{
+  return sim_store_commit(coreid, saddr, sdata, smask);
+}
+
+void SpikeProxy::exec(uint64_t n)
+{
+  sim_exec(coreid, n);
+}
+
+vaddr_t SpikeProxy::guided_exec(void *disambiguate_para)
+{
+  return sim_guided_exec(coreid, disambiguate_para);
+}
+
+void SpikeProxy::update_config(void *config)
+{
+  sim_update_config(coreid, config);
+}
+
+void SpikeProxy::raise_intr(uint64_t no)
+{
+  sim_raise_intr(coreid, no);
+}
+
+void SpikeProxy::isa_reg_display()
+{
+  sim_isa_reg_display(coreid);
+}
+
+void SpikeProxy::query(void *result_buffer, uint64_t type)
+{
+  sim_query(coreid, result_buffer, type);
 }


### PR DESCRIPTION
For multicore, only one Spike .so library connects to difftest.